### PR TITLE
SCM-Manager 1.49 and LDAP compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
   <parent>
     <artifactId>scm-plugins</artifactId>
     <groupId>sonia.scm.plugins</groupId>
-    <version>1.45</version>
+    <version>1.49</version>
   </parent>
 
   <groupId>com.aquenos.scm</groupId>
   <artifactId>scm-ssh-plugin</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>${project.artifactId}</name>
   <description>SSH support for SCM.</description>
   <url>https://github.com/litesolutions/scm-ssh-plugin/</url>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.47</version>
+      <version>1.49</version>
     </dependency>
 
     <!-- test scope -->

--- a/src/main/java/com/aquenos/scm/ssh/auth/PublicKeyAuthenticator.java
+++ b/src/main/java/com/aquenos/scm/ssh/auth/PublicKeyAuthenticator.java
@@ -65,7 +65,7 @@ public class PublicKeyAuthenticator {
 			PublicKey publicKey) {
 		User user = userManager.get(username);
 		if (user != null) {
-			if (userManager.getDefaultType().equals(user.getType())) {
+			//if (userManager.getDefaultType().equals(user.getType())) {
 				List<PublicKey> keysForUser = getPublicKeysForUser(user);
 				if (keysForUser == null) {
 					return AuthenticationResult.NOT_FOUND;
@@ -76,7 +76,7 @@ public class PublicKeyAuthenticator {
 				} else {
 					return AuthenticationResult.FAILED;
 				}
-			}
+			//}
 		}
 		return AuthenticationResult.NOT_FOUND;
 	}


### PR DESCRIPTION
Hi,

I have made some changes so it would work properly on my use case, we have the ldap plugin too so for the keys to work properly I had to remove the code that forced the users to be from XML.
Since I am using 1.49 I had to change the parent and rebuild the plugin too.
